### PR TITLE
Gérer le stock par nom ou par modèle

### DIFF
--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/ajax/dropdownLocations.php
+++ b/ajax/dropdownLocations.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/ajax/dropdownNumber.php
+++ b/ajax/dropdownNumber.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/ajax/dropdownTickets.php
+++ b/ajax/dropdownTickets.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/gestion.php
+++ b/front/gestion.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -51,8 +51,8 @@ if (isset($_POST["add"])) {
    if (isset($_GET['tickets_id'])) {
       $_POST['tickets_id'] = $_GET['tickets_id'];
    }
-   $newID = $PluginReservation->add($_POST);
-   if ($newID) {
+   if ($newID = $PluginReservation->add($_POST)) {
+
       Event::log($newID, "geststock", 4, "tools",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $newID));
    }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/reservation_item.form.php
+++ b/front/reservation_item.form.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -87,18 +87,19 @@ if (isset($_POST["upload"])) {
                                       [$field        => $value,
                                        'entities_id' => $config->fields['entities_id_stock'],
                                        $itemsid      => $ri->fields['models_id']]);
-                  if ($data = $req->next()) {
-                     toolbox::logdebug("data ", $data);
+                  $find = false;
+                  foreach ($req as $data) {
+                     $find = true;
                      // stock id of item
                       if ($item->getFromDB($data['id'])
                           && ($item->getField('states_id') == $config->fields['stock_status'])) {
                          $tabid[] = $data['id'];
-                         toolbox::logdebug("tabid", $tabid);
                       } else {
                          Session::addMessageAfterRedirect(__('The item with this number is not free',
                                                              'geststock'), false, ERROR);
                       }
-                  } else {
+                  }
+                  if ($find == false) {
                      Session::addMessageAfterRedirect(sprintf(__('Item not found with this %s number',
                                                                  'geststock'), $field." ".$value),
                                                       false, ERROR);

--- a/front/reservation_item.php
+++ b/front/reservation_item.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/front/specification.form.php
+++ b/front/specification.form.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/geststock.xml
+++ b/geststock.xml
@@ -25,13 +25,18 @@
     </authors>
     <versions>
       <version>
+          <num>2.1.1</num>
+          <compatibility>~10.0.3</compatibility>
+          <download_url>https://github.com/yllen/geststock/releases/download/v2.1.1/glpi-geststock-2.1.1.tar.gz</download_url>
+      </version>
+      <version>
           <num>2.1.0</num>
           <compatibility>10.0.3</compatibility>
           <download_url>https://github.com/yllen/geststock/releases/download/v2.1.0/glpi-geststock-2.1.0.tar.gz</download_url>
       </version>
       <version>
           <num>2.0.0</num>
-          <compatibility>9.5.3</compatibility>
+          <compatibility>~9.5.3</compatibility>
           <download_url>https://github.com/yllen/geststock/releases/download/v2.0.0/glpi-geststock-2.0.0.tar.gz</download_url>
       </version>
       <version>

--- a/geststock.xml
+++ b/geststock.xml
@@ -24,8 +24,13 @@
         <author>Nelly Mahu-Lasson</author>
     </authors>
     <versions>
-        <version>
-          <num>2.0.0.0</num>
+      <version>
+          <num>2.1.0</num>
+          <compatibility>10.0.3</compatibility>
+          <download_url>https://github.com/yllen/geststock/releases/download/v2.1.0/glpi-geststock-2.1.0.tar.gz</download_url>
+      </version>
+      <version>
+          <num>2.0.0</num>
           <compatibility>9.5.3</compatibility>
           <download_url>https://github.com/yllen/geststock/releases/download/v2.0.0/glpi-geststock-2.0.0.tar.gz</download_url>
       </version>

--- a/hook.php
+++ b/hook.php
@@ -236,7 +236,7 @@ function plugin_geststock_getAddSearchOptionsNew($itemtype) {
                  'name'       =>  __('Length', 'geststock'),
                  'datatype'   =>  'number',
                  'joinparams' => ['jointype'  => 'child',
-                                  'condition' => [NEWTABLE.'.itemtype' => $obj],
+                                  'condition' => ['NEWTABLE.itemtype' => $obj],
                                   'linkfield' => 'models_id']];
 
        $tab[] = ['id'         => '4',

--- a/hook.php
+++ b/hook.php
@@ -99,7 +99,7 @@ function plugin_geststock_uninstall() {
    include_once(Plugin::getPhpDir('geststock')."/inc/specification.class.php");
    PluginGeststockSpecification::uninstall();
 
-   include_once(GLPI_ROOT."/plugins/geststock/inc/reservation_item_number.class.php");
+   include_once(Plugin::getPhpDir('geststock')."/inc/reservation_item_number.class.php");
    PluginGeststockReservation_Item_Number::uninstall();
 
    include_once(Plugin::getPhpDir('geststock')."/inc/menu.class.php");

--- a/hook.php
+++ b/hook.php
@@ -31,7 +31,7 @@
 function plugin_geststock_install() {
    global $DB;
 
-   $migration = new Migration(140);
+   $migration = new Migration(210);
 
    include_once(Plugin::getPhpDir('geststock')."/inc/gestion.class.php");
 
@@ -63,6 +63,8 @@ function plugin_geststock_install() {
    if (!is_dir(PLUGIN_GESTSTOCK_UPLOAD_DIR)) {
       mkdir(PLUGIN_GESTSTOCK_UPLOAD_DIR);
    }
+
+   $migration->executeMigration();
 
    return true;
 }
@@ -112,6 +114,8 @@ function plugin_geststock_uninstall() {
       $item = new $itemtype;
       $item->deleteByCriteria(['itemtype' => 'PluginGeststockReservation']);
    }
+
+   $migration->executeMigration();
 
    return true;
 }

--- a/hook.php
+++ b/hook.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -138,9 +138,8 @@ function plugin_geststock_giveItem($type, $ID, $data, $num) {
          $number_device = count($result_device);
          $out           = '';
          if ($number_device > 0) {
-            for ($y=0 ; $y < $number_device ; $y++) {
+            foreach ($result_device as $row) {
                $column = "name";
-               $row    = $result_device->next();
                $type   = $row['itemtype'];
                if (!($item = $dbu->getItemForItemtype($type))) {
                   continue;
@@ -165,7 +164,7 @@ function plugin_geststock_giveItem($type, $ID, $data, $num) {
                             'ORDER'     => $colname];
                   if ($result_linked = $DB->request($query)) {
                      if (count($result_linked)) {
-                        while ($data = $result_linked->next()) {
+                        foreach ($result_linked as $data) {
                            $out .= $data['nbrereserv']. " ".$item->getTypeName($data['nbrereserv'])." - ".$data['name']."<br>";
 
                         }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -50,7 +50,7 @@ class PluginGeststockConfig extends CommonDBTM {
                      `entities_id_stock` int(11) NULL,
                      `stock_status` int(11) NULL,
                      `transit_status` int(11) NULL,
-                     `date_mod` datetime default NULL,
+                     `date_mod` timestamp NULL DEFAULT NULL,
                      `users_id` int(11) NULL,
                      `criterion` varchar(100) NOT NULL,
                      PRIMARY KEY  (`id`),

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -136,9 +136,11 @@ class PluginGeststockConfig extends CommonDBTM {
 
       echo "<tr class='tab_bg_1'><td class='center' colspan='2'>";
       if ($config->getFromDB(1)) {
-         echo "<input type='submit' name='update' value='Modifier' class='submit' ></td>";
+         echo Html::submit(_sx('button', 'Update'), ['name'  => 'update',
+                                                     'class' => 'btn btn-primary']);
       } else {
-         echo "<input type='submit' name='add' value='Ajouter' class='submit' ></td>";
+         echo Html::submit(_sx('button', 'Add'), ['name'  => 'add',
+                                                  'class' => 'btn btn-primary']);
       }
       echo "</td></tr></table>";
       HTML::closeForm();

--- a/inc/followup.class.php
+++ b/inc/followup.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -83,7 +83,7 @@ class PluginGeststockFollowup extends CommonDBTM {
                                 'addicon'  => false,
                                 'comments' => false]);
             echo "<br><br>\n";
-            echo Html::submit(_x('button', 'Move'), ['name' => 'massiveaction'])."</span>";
+            echo Html::submit(_sx('button', 'Move'), ['name' => 'massiveaction'])."</span>";
             return true;
       }
       return parent::showMassiveActionsSubForm($ma);

--- a/inc/followup.class.php
+++ b/inc/followup.class.php
@@ -43,7 +43,7 @@ class PluginGeststockFollowup extends CommonDBTM {
                      `locations_id_old` int(11) NULL,
                      `locations_id_new` int(11) NULL,
                      `users_id` int(11) NULL,
-                     `date_mod` datetime default NULL,
+                     `date_mod` timestamp NULL DEFAULT NULL,
                      PRIMARY KEY (`id`),
                      KEY `plugin_geststock_reservations_id` (`plugin_geststock_reservations_id`),
                      KEY `plugin_geststock_reservations_items_id` (`plugin_geststock_reservations_items_id`),

--- a/inc/gestion.class.php
+++ b/inc/gestion.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -43,9 +43,10 @@ class PluginGeststockMenu extends CommonGLPI {
 
    static function getMenuContent() {
 
+      $locinstall = Plugin::getPhpDir('geststock', false);
       $menu                      = [];
       $menu['title']             = self::getMenuName();
-      $menu['page']              = "/plugins/geststock/front/reservation.php";
+      $menu['page']              = $locinstall."/front/reservation.php";
       $menu['links']['search']   = PluginGeststockReservation::getSearchURL(false);
 
       if (Session::haveRight('plugin_geststock', CREATE)) {

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -117,7 +117,8 @@ class PluginGeststockProfile extends Profile {
       if ($canedit) {
          echo "<div class='center'>";
          echo Html::hidden('id', ['value' => $ID]);
-         echo Html::submit(_sx('button', 'Save'), ['name' => 'update']);
+         echo Html::submit(_sx('button', 'Update'), ['name'  => 'update',
+                                                     'class' => 'btn btn-primary']);
          echo "</div>\n";
          Html::closeForm();
       }

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -425,14 +425,14 @@ class PluginGeststockReservation extends CommonDBTM {
                      `status` int(11) NOT NULL DEFAULT '1',
                      `comment` text COLLATE utf8_unicode_ci,
                      `is_deleted` tinyint(1) NOT NULL default '0',
-                     `date_reserv` DATE COLLATE utf8_unicode_ci NULL,
-                     `date_whished` DATE COLLATE utf8_unicode_ci NULL,
-                     `receipt_date` DATE COLLATE utf8_unicode_ci NULL,
-                     `date_tova` DATE COLLATE utf8_unicode_ci NULL,
+                     `date_reserv` timestamp NULL DEFAULT NULL,
+                     `date_whished` timestamp NULL DEFAULT NULL,
+                     `receipt_date` timestamp NULL DEFAULT NULL,
+                     `date_tova` timestamp NULL DEFAULT NULL,
                      `number_tova` varchar(255) NULL,
                      `type_tova` int(11) NULL,
                      `number_package` int(11) NULL,
-                     `date_mod` datetime DEFAULT NULL,
+                     `date_mod` timestamp NULL DEFAULT NULL,
                     PRIMARY KEY (`id`),
                     UNIQUE `unicity` (`entities_id_deliv`, `tickets_id`),
                     KEY `users_id` (`users_id`),
@@ -443,6 +443,13 @@ class PluginGeststockReservation extends CommonDBTM {
 
          $DB->queryOrDie($query, 'Error in creating glpi_plugin_geststock_reservations'.
                          "<br>".$DB->error());
+      } else {
+         // migration to 2.1.0
+         $mig->changeField($table, 'date_reserv', 'date_reserv', "timestamp NULL DEFAULT NULL");
+         $mig->changeField($table, 'date_whished', 'date_whished', "timestamp NULL DEFAULT NULL");
+         $mig->changeField($table, 'receipt_date', 'receipt_date', "timestamp NULL DEFAULT NULL");
+         $mig->changeField($table, 'date_tova', 'date_tova', "timestamp NULL DEFAULT NULL");
+         $mig->changeField($table, 'date_mod', 'date_mod', "timestamp NULL DEFAULT NULL");
       }
    }
 

--- a/inc/reservation.class.php
+++ b/inc/reservation.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -322,9 +322,9 @@ class PluginGeststockReservation extends CommonDBTM {
          echo "<tr class='tab_bg_1'>";
          echo "<td>".__('Ticket')."</td>";
          echo "<td colspan='3'>".Dropdown::getDropdownName('glpi_tickets', $ticket->fields['id']);
-         echo "<input type='hidden' name='entities_id_deliv' value='".$ticket->fields['entities_id']."'>";
-         echo "<input type='hidden' name='tickets_id' value='".$options['tickets_id']."'>";
-         echo "<input type='hidden' name='_fromticket' value=1>";
+         echo Html::hidden('entities_id_deliv', ['value' => $ticket->fields['entities_id']]);
+         echo Html::hidden('tickets_id', ['value' => $options['tickets_id']]);
+         echo Html::hidden('_fromticket', ['value' => 1]);
 
       } else {
          echo "<tr class='tab_bg_1'>";
@@ -365,8 +365,7 @@ class PluginGeststockReservation extends CommonDBTM {
                                            'maybeempty' => true]);
          echo "</td>";
          echo "<td>Numéro de valise</td><td>";
-         Html::autocompletionTextField($this,'number_tova',
-                                       ['value' => $this->fields["number_tova"]]);
+         echo Html::input('number_tova', ['value' => $this->fields["number_tova"]]);
          echo "</td></tr>";
 
          echo "<tr class='tab_bg_1'>";
@@ -388,10 +387,14 @@ class PluginGeststockReservation extends CommonDBTM {
       echo "<tr class='tab_bg_1'>";
       echo "<td rowspan='5'>".__('Comments')."</td>";
       echo "<td rowspan='5' class='middle' colspan='3'>";
-      echo "<textarea style='width:95%' rows='5' name='comment' >".$this->fields["comment"];
+      Html::textarea(['name'            => 'comment',
+                      'value'           => $this->fields["comment"],
+                      'enable_richtext' => false,
+                      'rows'            => '5',
+                      'style'           => 'width:95%']);
       echo "</textarea>";
       if (empty($this->fields['date_reserv'])) {
-         echo "<input type='hidden' name='date_reserv' value='".$_SESSION["glpi_currenttime"]."'>";
+         echo Html::hidden('date_reserv', ['value' => $_SESSION["glpi_currenttime"]]);
       }
       echo "</td></tr>\n";
 
@@ -982,8 +985,8 @@ class PluginGeststockReservation extends CommonDBTM {
             echo "<th colspan='3'>".__('Add a reservation', 'geststock')."</th></tr>";
 
             echo "<tr class='tab_bg_2 center'><td>";
-            echo "<input type='hidden' name='tickets_id' value='$ID'>";
-            echo "<input type='hidden' name='entities_id' value='".$ticket->fields['entities_id']."'>";
+            echo Html::hidden('tickets_id', ['value' => $ID]);
+            echo Html::hidden('entities_id', ['value' => $ticket->fields['entities_id']]);
             if (Session::haveRight(self::$rightname, CREATE)) {
                echo "<a href='".Toolbox::getItemTypeFormURL(__CLASS__)."?tickets_id=$ID'>";
                echo __('Create a reservation from this ticket', 'geststock');
@@ -1086,10 +1089,10 @@ class PluginGeststockReservation extends CommonDBTM {
 
       $pdf->setColumnsSize(50,50);
       $pdf->displayLine(sprintf(__('%1$s: %2$s'), '<b><i>'.__('Ticket').'</i></b>',
-                                Html::clean(Dropdown::getDropdownName('glpi_tickets',
-                                                                      $this->fields['tickets_id']))),
+                                Toolbox::stripTags(Dropdown::getDropdownName('glpi_tickets',
+                                                                             $this->fields['tickets_id']))),
                         sprintf(__('%1$s: %2$s'), '<b><i>'.__('Status').'</i></b>',
-                                Html::clean(self::getStatusName($this->fields['status']))));
+                                Toolbox::stripTags(self::getStatusName($this->fields['status']))));
 
       $pdf->displayLine(sprintf(__('%1$s: %2$s'), '<b><i>'.__('Delivery date', 'geststock').'</i></b>',
                                 Html::convDateTime($this->fields['date_whished'])),
@@ -1103,7 +1106,7 @@ class PluginGeststockReservation extends CommonDBTM {
                            sprintf(__('%1$s: %2$s'), '<b><i>Numéro de valise </i></b>',
                                    $this->fields['number_tova']),
                            sprintf(__('%1$s: %2$s'), '<b><i>Type de valise </i></b>',
-                                    Html::clean(self::getStatusTova($this->fields['type_tova']))));
+                                    Toolbox::stripTags(self::getStatusTova($this->fields['type_tova']))));
       }
 
       $pdf->setColumnsSize(100);
@@ -1195,8 +1198,9 @@ class PluginGeststockReservation extends CommonDBTM {
                               )
                            )";
       if ($result = $DB->request($query)) {
-         $row = $result->next();
+         foreach ($result as $row) {
             return $row['cpt'];
+         }
       }
          return false;
       }

--- a/inc/reservation_item.class.php
+++ b/inc/reservation_item.class.php
@@ -289,7 +289,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
       }
 
       $i = $volume = $weight = $totvolume = $totweight = $j = 0;
-      echo "<div class='center'>";
+      echo "<div>";
       if ($canupdate && ($resa->fields['status'] < PluginGeststockReservation::RECEIPT)) {
          Html::openMassiveActionsForm('mass'.__CLASS__.$rand);
          $massiveactionparams = ['container' => 'mass'.__CLASS__.$rand];

--- a/inc/reservation_item.class.php
+++ b/inc/reservation_item.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -203,8 +203,9 @@ class PluginGeststockReservation_Item extends CommonDBChild {
          $config->getFromDB(1);
          $entity = $config->fields['entities_id_stock'];
          PluginGeststockReservation::showAllItems("model", 0, 0, $entity);
-         echo "<input type='submit' name='additem' value='".__('Add')."' class='submit'>";
-         echo "<input type='hidden' name='reservations_id' value='$instID'>";
+         echo Html::submit(_sx('button', 'Add'), ['name'  => 'additem',
+                                                  'class' => 'btn btn-primary']);
+         echo Html::hidden('reservations_id', ['value' => $instID]);
          echo "</td></tr>";
          echo "</table>";
          Html::closeForm();
@@ -321,8 +322,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
       $header_end .= "<tr>";
       echo $header_begin.$header_top.$header_end;
 
-      for ($i=0 ; $i < $number ; $i++) {
-         $row = $result->next();
+      foreach ($result as $row) {
          $type = $row['itemtype'];
          if (!($item = $dbu->getItemForItemtype($type))) {
            continue;
@@ -352,7 +352,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
                                              _n('Stock reservation', 'Stock reservations', 2,
                                                 'geststock')." = ".$resa->getNameID());
 
-               while ($data = $result_linked->next()) {
+               foreach ($result_linked as $data) {
                   $item->getFromDB($data["id"]);
                   Session::addToNavigateListItems($type,$data["id"]);
                   if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
@@ -428,8 +428,8 @@ class PluginGeststockReservation_Item extends CommonDBChild {
 
       if ($canupdate && ($resa->fields['status'] < PluginGeststockReservation::RECEIPT)) {
          echo "<tr class='tab_bg_1'><td colspan='3' class='center'>";
-         echo "<input type='hidden' name='users_id' value='".Session::getLoginUserID()."'>";
-         echo "<input type='hidden' name='reservations_id' value='".$resa->getField('id')."'>";
+         echo Html::hidden('users_id', ['value' => Session::getLoginUserID()]);
+         echo Html::hidden('reservations_id', ['value' => $resa->getField('id')]);
          echo "</td></tr>";
          echo "</table></div>" ;
 
@@ -580,10 +580,12 @@ class PluginGeststockReservation_Item extends CommonDBChild {
       }
       if ($canupdate) {
          echo "<tr class='tab_bg_1'><td></td><td colspan='2' class='center'>";
-         echo "<input type='submit' name='addotherserial' value='".__('Update')."' class='submit'>";
-         echo "</td><td><input type='submit' name='upload' value='".__('Upload files', 'geststock')."'
-                         class='submit'>";
-         echo "<input type='hidden' name='reservations_id' value='$instID'>";
+         echo Html::submit(_sx('button', 'Update'), ['name'  => 'addotherserial',
+                                                     'class' => 'btn btn-primary']);
+         echo "</td><td>">
+         echo Html::submit(__('Upload files', 'geststock'), ['name'  => 'upload',
+                                                             'class' => 'btn btn-primary']);
+         echo Html::hidden('reservations_id', ['value' => $instID]);
          echo "</td></tr>";
       }
       echo "</table>";
@@ -779,7 +781,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
                                 'addicon'  => false,
                                 'comments' => false]);
             echo "<br><br>\n";
-            echo Html::submit(_x('button', 'Move'), ['name' => 'massiveaction'])."</span>";
+            echo Html::submit(_sx('button', 'Move'), ['name' => 'massiveaction'])."</span>";
             return true;
       }
       return parent::showMassiveActionsSubForm($ma);
@@ -892,8 +894,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
       if (!$number) {
          $pdf->displayLine(__('No item found'));
       } else {
-         for ($i=0 ; $i < $number ; $i++) {
-            $row = $result->next();
+         foreach ($result as $row) {
             $type = $row['itemtype'];
             if (!($item = $dbu->getItemForItemtype($type))) {
                continue;
@@ -919,7 +920,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
             $dbu = new DbUtils();
             if ($result_linked = $DB->request($query)) {
                if (count($result_linked)) {
-                  while ($data = $result_linked->next()) {
+                  foreach ($result_linked as $data) {
                      $item->getFromDB($data["id"]);
                      $name = $data["name"];
                      if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {

--- a/inc/reservation_item.class.php
+++ b/inc/reservation_item.class.php
@@ -582,7 +582,7 @@ class PluginGeststockReservation_Item extends CommonDBChild {
          echo "<tr class='tab_bg_1'><td></td><td colspan='2' class='center'>";
          echo Html::submit(_sx('button', 'Update'), ['name'  => 'addotherserial',
                                                      'class' => 'btn btn-primary']);
-         echo "</td><td>">
+         echo "</td><td>";
          echo Html::submit(__('Upload files', 'geststock'), ['name'  => 'upload',
                                                              'class' => 'btn btn-primary']);
          echo Html::hidden('reservations_id', ['value' => $instID]);

--- a/inc/reservation_item_number.class.php
+++ b/inc/reservation_item_number.class.php
@@ -101,7 +101,6 @@ class PluginGeststockReservation_Item_Number extends CommonDBChild {
       global $DB;
 
       $tables = ['glpi_plugin_geststock_reservations_items_numbers'];
-
       foreach ($tables as $table) {
          $query = "DROP TABLE IF EXISTS `$table`";
          $DB->queryOrDie($query, $DB->error());

--- a/inc/reservation_item_number.class.php
+++ b/inc/reservation_item_number.class.php
@@ -20,7 +20,7 @@ along with GestStock. If not, see <http://www.gnu.org/licenses/>.
 
 @package   geststock
 @author    Nelly Mahu-Lasson
-@copyright Copyright (c) 2017-2021 GestStock plugin team
+@copyright Copyright (c) 2017-2022 GestStock plugin team
 @license   AGPL License 3.0 or (at your option) any later version
 http://www.gnu.org/licenses/agpl-3.0-standalone.html
 @link

--- a/inc/reservation_item_number.class.php
+++ b/inc/reservation_item_number.class.php
@@ -81,7 +81,7 @@ class PluginGeststockReservation_Item_Number extends CommonDBChild {
                      `locations_id_stock` int(11) NULL,
                      `otherserial` text COLLATE utf8_unicode_ci,
                      `users_id` int(11) NULL,
-                     `date_mod` datetime default NULL,
+                     `date_mod` timestamp NULL DEFAULT NULL,
                      PRIMARY KEY (`id`),
                      KEY `plugin_geststock_reservations_items_id` (`plugin_geststock_reservations_items_id`),
                      KEY `users_id` (users_id),
@@ -90,7 +90,10 @@ class PluginGeststockReservation_Item_Number extends CommonDBChild {
 
          $DB->queryOrDie($query, 'Error in creating glpi_plugin_geststock_reservations_items_numbers'.
                "<br>".$DB->error());
-      }
+      } else {
+         // migration to 2.1.0
+         $mig->changeField($table, 'date_mod', 'date_mod', "timestamp NULL DEFAULT NULL");
+      }      
    }
 
 

--- a/inc/reservationpdf.class.php
+++ b/inc/reservationpdf.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/inc/specification.class.php
+++ b/inc/specification.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
  http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -84,20 +84,17 @@ class PluginGeststockSpecification extends CommonDBTM {
        }
        echo "<tr class='tab_bg_1'>";
        echo "<td>".__('Length', 'geststock')."</td><td>";
-       Html::autocompletionTextField($spec, "length",
-                                     ["value" => isset($data['length']) ? $data['length'] : '0']);
+       echo Html::input("length", ["value" => isset($data['length']) ? $data['length'] : '0']);
        echo "&nbsp; cm</td></tr>";
 
        echo "<tr class='tab_bg_1'>";
        echo "<td>".__('Width', 'geststock')."</td><td>";
-       Html::autocompletionTextField($spec, "width",
-                                     ["value" => isset($data['width']) ? $data['width'] : '0']);
+       echo Html::input("width", ["value" => isset($data['width']) ? $data['width'] : '0']);
        echo "&nbsp; cm</td></tr>";
 
        echo "<tr class='tab_bg_1'>";
        echo "<td>".__('Height', 'geststock')."</td><td>";
-       Html::autocompletionTextField($spec, "height",
-                                     ["value" => isset($data['height']) ? $data['height'] : '0']);
+       echo Html::input("height", ["value" => isset($data['height']) ? $data['height'] : '0']);
        echo "&nbsp; cm</td></tr>";
 
        echo "<tr class='tab_bg_1'>";
@@ -114,12 +111,14 @@ class PluginGeststockSpecification extends CommonDBTM {
 
        echo "<tr'><td class='center'>";
        if (isset($data['id'])) {
-         echo "<input type='submit' name='update' value='".__('Update')."' class='submit'>";
-         echo "<input type='hidden' name='id' value='".$data['id']."'>";
+         echo Html::submit(_sx('button', 'Update'), ['name' => 'update',
+                                                     'class' => 'btn btn-primary']);
+         echo Html::hidden('id', ['value' => $data['id']]);
        } else {
-         echo "<input type='submit' name='add' value='".__('Add')."' class='submit'>";
-         echo "<input type='hidden' name='models_id' value='".$item->fields['id']."'>";
-         echo "<input type='hidden' name='itemtype' value='".$type."'>";
+         echo Html::submit(_sx('button', 'Add'), ['name' => 'add',
+                                                  'class' => 'btn btn-primary']);
+         echo Html::hidden('models_id',  ['value' => $item->fields['id']]);
+         echo Html::hidden('itemtype', ['value' => $type]);
        }
        echo "</td></tr>";
        echo "</table>" ;

--- a/inc/specification.class.php
+++ b/inc/specification.class.php
@@ -143,13 +143,16 @@ class PluginGeststockSpecification extends CommonDBTM {
                      `height` int(11) NULL,
                      `weight` decimal(6,3) NOT NULL DEFAULT '000.000',
                      `volume` float NULL,
-                     `date_mod` datetime DEFAULT NULL,
+                     `date_mod` timestamp NULL DEFAULT NULL,
                     PRIMARY KEY (`id`),
                     UNIQUE `unicity` (`models_id`, `itemtype`)
                   ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
 
           $DB->queryOrDie($query, 'Error in creating glpi_plugin_geststock_specifications'.
                            "<br>".$DB->error());
+      } else {
+         // migration to 2.1.0
+         $mig->changeField($table, 'date_mod', 'date_mod', "timestamp NULL DEFAULT NULL");
       }
     }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -38,6 +38,13 @@ class PluginGeststockTicket {
           && ($ticket->input['status'] == CommonITILObject::CLOSED)) {
          $reservation = new PluginGeststockReservation();
          $reservation->transfertItem($ticket->input['id']);
+         // transfert only if not done
+         foreach ($DB->request('glpi_plugin_geststock_reservations',
+                               ['tickets_id' => $ticket->input['id']]) as $resa) {
+             if ($reservation->getFromDB($resa['id']) && is_null($resa['receipt_date'])) {
+                $reservation->transfertItem($ticket->input['id']);
+             }
+         }
       }
    }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -55,9 +55,10 @@ class PluginGeststockTicket {
                                ['tickets_id' => $ticket->input['id']]) as $resa) {
 
             // no transfert if count items selected <> items reserved
-            $resaid = $resa['id'];
+            $req = $DB->request("glpi_plugin_geststock_reservations_items",
+                                ['plugin_geststock_reservations_id' => $resa['id']]);
 
-            if ($resaitem->getFromDBByCrit(['plugin_geststock_reservations_id' => $resaid])) {
+            if ($req->count())) {
                foreach ($DB->request("glpi_plugin_geststock_reservations_items",
                                      ['plugin_geststock_reservations_id' => $resa['id']]) as $resait) {
                   $resaitid = $resait['id'];

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link

--- a/setup.php
+++ b/setup.php
@@ -80,7 +80,7 @@ function plugin_init_geststock() {
 function plugin_version_geststock() {
 
    return ['name'           => __('Stock gestion', 'geststock'),
-           'version'        => '2.1.0',
+           'version'        => '2.1.1',
            'author'         => 'Nelly Mahu-Lasson',
            'license'        => 'GPLv3+',
            'homepage'       => 'https://github.com/yllen/geststock',

--- a/setup.php
+++ b/setup.php
@@ -20,7 +20,7 @@
 
  @package   geststock
  @author    Nelly Mahu-Lasson
- @copyright Copyright (c) 2017-2021 GestStock plugin team
+ @copyright Copyright (c) 2017-2022 GestStock plugin team
  @license   AGPL License 3.0 or (at your option) any later version
             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  @link
@@ -80,14 +80,14 @@ function plugin_init_geststock() {
 function plugin_version_geststock() {
 
    return ['name'           => __('Stock gestion', 'geststock'),
-           'version'        => '2.0.0',
+           'version'        => '2.1.0',
            'author'         => 'Nelly Mahu-Lasson',
            'license'        => 'GPLv3+',
            'homepage'       => 'https://github.com/yllen/geststock',
            'page'           => "/front/reservation.php",
-           'minGlpiVersion' => '9.5.3',
-           'requirements'   => ['glpi' => ['min' => '9.5.3',
-                                           'max' => '9.6']]];
+           'minGlpiVersion' => '10.0.3',
+           'requirements'   => ['glpi' => ['min' => '10.0.3',
+                                           'max' => '11.0.0']]];
 }
 
 


### PR DESCRIPTION
Bonjour,

Dans l'organisation que nous avons, nous nommons les ordinateurs par rapport à leur filiale (CLIxxx pour des PC de la filale Claris, NLxxx pour NewLoc...), aussi, l'utilisation de ce plugin est, sur le fond, intéressante pour nous, mais sur la forme, pas très agile.
Serait-il possible de prévoir de créer et afficher les stocks par nom de matériel ? Au pire, peut-être au choix entre modèle et nom, puisque je pense que les 2 peuvent convenir aux différents utilisateurs.

Merci