### PR TITLE
Fix Unclosed '{' on line 62 does not match ')'

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -65,7 +65,7 @@ class PluginGeststockTicket {
             $req = $DB->request("glpi_plugin_geststock_reservations_items",
                                 ['plugin_geststock_reservations_id' => $resa['id']]);
 
-            if ($req->count())) {
+            if ($req->count()) {
                foreach ($DB->request("glpi_plugin_geststock_reservations_items",
                                      ['plugin_geststock_reservations_id' => $resa['id']]) as $resait) {
                   $resaitid = $resait['id'];


### PR DESCRIPTION
glpiphplog.CRITICAL:   *** Uncaught Exception ParseError: Unclosed '{' on line 62 does not match ')' in /var/www/html/glpi/marketplace/geststock/inc/ticket.class.php at line 68